### PR TITLE
Add .onCloseClick as promise-like API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.1.0] - 2022-11-04
+### Added
+- Added .onCloseClick as awaitable promise to permit to create easier flow
+
 ## [3.0.0] - 2022-11-03
 ### Added
 - The new version runs in React 18 using Functional Component as internal implementation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [3.2.0] - 2022-11-04
+### Added
+- Removed manager.closedPopups API
+
 ## [3.1.0] - 2022-11-04
 ### Added
 - Added .onCloseClick as awaitable promise to permit to create easier flow

--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ import { MyModal } from './MyModal'
 
 export const Main = () => {
   const popupManager = usePopupManager();
-  const openModal = () => {
+  const openModal = async () => {
     // open MyModal with it's needed `props` and an `onCloseClick` callback function
-    popupManager.open(MyModal, {
+    let result = await popupManager.open(MyModal, {
       title: 'my modal',
-      onClose: (...params) => console.log('modal has closed with:', ...params), // modal has closed with: param param2 param3
-    }); 
+    }).onCloseClick((...params) => 'modal has closed with:', ...params);
+    console.log(result) // 'modal has closed with: param, param2, param3'
   }
   return (
       <div>

--- a/__tests__/test_performance.tsx
+++ b/__tests__/test_performance.tsx
@@ -1,0 +1,67 @@
+import '@testing-library/jest-dom'
+import React from 'react';
+
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PopupManager, PopupProps, PopupProvider, usePopupManager } from '../dist';
+
+let renderCounter = 0;
+
+const onCloseSpy = jest.fn();
+interface PopupComponentProps {
+    customProps: string,
+}
+
+function PopupComponent({onCloseClick, show, customProps}: PopupComponentProps & PopupProps){
+    renderCounter++;
+    if(!show){
+        return null;
+    } 
+
+    return <div>
+        I am a visible popup. Custom Props: {customProps} -
+        <button onClick={onCloseClick}>Close Popup</button>
+    </div>
+}
+
+const SomeContent = () => {
+    const popupManager = usePopupManager();
+    const open = () => popupManager?.open<PopupComponentProps>(PopupComponent, {
+        customProps: 'Montacchiello',
+        onCloseClick: onCloseSpy,
+    });
+
+    return <div>
+        Some random content
+        <button onClick={open}>Open popup</button>
+    </div>
+}
+
+const ComponentHelper = () => {
+    const [mounted, setMounted] = React.useState(true)
+    const manager = new PopupManager();
+    manager.deletionTimeout = 0;
+    return <PopupProvider manager={manager}>
+        { mounted && <SomeContent />}
+        <button onClick={() => setMounted(false)}>Unmount the content</button>
+    </PopupProvider>;
+}
+
+describe('Popup', () => {
+    it('render the PopupComponent 1 time when opened', async () => {
+        render(<ComponentHelper/>)
+
+        await userEvent.click(screen.getByText(/Open popup/));
+        await userEvent.click(screen.getByText(/Close Popup/));
+        await userEvent.click(screen.getByText(/Open popup/));
+        await userEvent.click(screen.getByText(/Close Popup/));
+        await userEvent.click(screen.getByText(/Open popup/));
+        await waitFor(() => {
+            expect(renderCounter).toBe(5);
+        });
+    });
+
+   
+    
+   
+})

--- a/__tests__/test_promise_like_scenario.tsx
+++ b/__tests__/test_promise_like_scenario.tsx
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event';
 import { PopupProps, PopupProvider, usePopupManager } from '../dist';
 
 const onCloseSpy = jest.fn();
-const onClosePromiseLikeSpy = jest.fn(x => x);
+const onClosePromiseLikeSpy = jest.fn(x => x+'extra_data');
 interface PopupComponentProps {
     customProps: string,
 }
@@ -45,10 +45,8 @@ const SomeContent = () => {
 }
 
 const ComponentHelper = () => {
-    const [mounted, setMounted] = React.useState(true)
     return <PopupProvider>
-        { mounted && <SomeContent />}
-        <button onClick={() => setMounted(false)}>Unmount the content</button>
+        <SomeContent />
     </PopupProvider>;
 }
 
@@ -70,7 +68,7 @@ describe('Popup', () => {
         expect(onClosePromiseLikeSpy).toHaveBeenCalledTimes(1);
         
         expect(screen.queryByText(/I am a visible popup\. Custom Props: Montacchiello/)).not.toBeInTheDocument();
-        expect(await screen.findByText(/I am a visible popup. Custom Props: first popup result/)).toBeInTheDocument();
+        expect(await screen.findByText(/I am a visible popup. Custom Props: first popup resultextra_data/)).toBeInTheDocument();
     });
     
     

--- a/__tests__/test_promise_like_scenario.tsx
+++ b/__tests__/test_promise_like_scenario.tsx
@@ -50,7 +50,7 @@ const ComponentHelper = () => {
     </PopupProvider>;
 }
 
-describe('Popup', () => {
+describe('manager.open().onCloseClick function', () => {
     it('render children of the Provider', () => {
         render(<ComponentHelper/>)
 

--- a/__tests__/test_promise_like_scenario.tsx
+++ b/__tests__/test_promise_like_scenario.tsx
@@ -1,0 +1,78 @@
+import '@testing-library/jest-dom'
+import React from 'react';
+
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PopupProps, PopupProvider, usePopupManager } from '../dist';
+
+const onCloseSpy = jest.fn();
+const onClosePromiseLikeSpy = jest.fn(x => x);
+interface PopupComponentProps {
+    customProps: string,
+}
+
+const PopupComponent = function({onCloseClick, show, customProps}: PopupComponentProps & PopupProps){
+    if(!show){
+        return null;
+    } 
+
+    return <div>
+        I am a visible popup. Custom Props: {customProps} -
+        <button onClick={() => onCloseClick('first popup result')}>Close Popup</button>
+    </div>
+}
+
+const SomeContent = () => {
+    const popupManager = usePopupManager();
+    const open = async () => {
+        let result = await (popupManager?.open<PopupComponentProps>(PopupComponent, {
+            customProps: 'Montacchiello',
+            onCloseClick: onCloseSpy,
+        })
+        .onCloseClick(onClosePromiseLikeSpy));
+
+        
+        popupManager?.open<PopupComponentProps>(PopupComponent, {
+            customProps: result,
+            onCloseClick: onCloseSpy,
+        });
+    }
+
+    return <div>
+        Some random content
+        <button onClick={open}>Open popup</button>
+    </div>
+}
+
+const ComponentHelper = () => {
+    const [mounted, setMounted] = React.useState(true)
+    return <PopupProvider>
+        { mounted && <SomeContent />}
+        <button onClick={() => setMounted(false)}>Unmount the content</button>
+    </PopupProvider>;
+}
+
+describe('Popup', () => {
+    it('render children of the Provider', () => {
+        render(<ComponentHelper/>)
+
+        expect(screen.getByText(/Some random content/)).toBeInTheDocument();
+    });
+
+    it('Can close the popup, setting .onCloseClick chaining and await it to open a new popup', async () => {
+        render(<ComponentHelper/>);
+        await userEvent.click(screen.getByText(/Open popup/));
+        
+        expect(await screen.findByText(/I am a visible popup\. Custom Props: Montacchiello/)).toBeInTheDocument();
+        onCloseSpy.mockClear();
+        await userEvent.click(screen.getByText(/Close Popup/));
+        expect(onCloseSpy).toHaveBeenCalledTimes(1);
+        expect(onClosePromiseLikeSpy).toHaveBeenCalledTimes(1);
+        
+        expect(screen.queryByText(/I am a visible popup\. Custom Props: Montacchiello/)).not.toBeInTheDocument();
+        expect(await screen.findByText(/I am a visible popup. Custom Props: first popup result/)).toBeInTheDocument();
+    });
+    
+    
+
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domotz/react-popup-manager",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Manage react popups, Modals, Lightboxes, Notifications, etc. easily",
   "license": "MIT",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domotz/react-popup-manager",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Manage react popups, Modals, Lightboxes, Notifications, etc. easily",
   "license": "MIT",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domotz/react-popup-manager",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Manage react popups, Modals, Lightboxes, Notifications, etc. easily",
   "license": "MIT",
   "main": "dist/index.js",
@@ -55,6 +55,7 @@
     "@types/react": "^18.0.24",
     "jest": "^29.2.2",
     "jest-environment-jsdom": "^29.2.2",
+    "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "yarn.lock"
   ],
   "scripts": {
-    "test": "yarn jest --env jsdom",
+    "test": "yarn build && yarn jest --env jsdom",
     "prepare": "yarn build",
     "build": "tsc"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domotz/react-popup-manager",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Manage react popups, Modals, Lightboxes, Notifications, etc. easily",
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/PopupItem/index.ts
+++ b/src/PopupItem/index.ts
@@ -4,6 +4,8 @@ type PopupItemProps = PopupProps & { [key: string]: any };
 
 export class PopupItem {
   private _isOpen: boolean;
+  private _onCloseClickPromise: Promise<any>;
+  private _onCloseClickPromiseHandler: {resolve: Function};
 
   constructor(
     public ComponentClass: any,
@@ -17,7 +19,32 @@ export class PopupItem {
     return this._isOpen;
   }
 
-  public close() {
+  public get onCloseClickPromise(): any {
+    if(!this._onCloseClickPromise){
+      this._onCloseClickPromise = new Promise((resolve, reject) => {
+        this._onCloseClickPromiseHandler = {
+          resolve,
+        }
+      })
+    }
+    return this._onCloseClickPromise;
+  }
+
+  public set onCloseClickPromise(cb: (args: any) => any){
+    if(!this._onCloseClickPromise){
+      this._onCloseClickPromise = new Promise((resolve, reject) => {
+        this._onCloseClickPromiseHandler = {
+          resolve,
+        }
+      })
+    }
+    this._onCloseClickPromise = this._onCloseClickPromise.then(cb);
+  }
+
+  public close(...params: any[]) {
     this._isOpen = false;
+    if(this._onCloseClickPromiseHandler){
+      this._onCloseClickPromiseHandler.resolve(...params)
+    }
   }
 }

--- a/src/PopupItem/index.ts
+++ b/src/PopupItem/index.ts
@@ -38,7 +38,7 @@ export class PopupItem {
         }
       })
     }
-    if(!cb){
+    if(cb){
       this._onCloseClickPromise = this._onCloseClickPromise.then(cb);
     }
   }

--- a/src/PopupItem/index.ts
+++ b/src/PopupItem/index.ts
@@ -21,7 +21,7 @@ export class PopupItem {
 
   public get onCloseClickPromise(): any {
     if(!this._onCloseClickPromise){
-      this._onCloseClickPromise = new Promise((resolve, reject) => {
+      this._onCloseClickPromise = new Promise((resolve) => {
         this._onCloseClickPromiseHandler = {
           resolve,
         }
@@ -38,7 +38,9 @@ export class PopupItem {
         }
       })
     }
-    this._onCloseClickPromise = this._onCloseClickPromise.then(cb);
+    if(!cb){
+      this._onCloseClickPromise = this._onCloseClickPromise.then(cb);
+    }
   }
 
   public close(...params: any[]) {

--- a/src/PopupManager/index.ts
+++ b/src/PopupManager/index.ts
@@ -54,10 +54,14 @@ export class PopupManager {
       this.callPopupsChangeEvents();
       return {
         close: () => this.close(guid),
+        onCloseClick: (cb) => {
+          newPopupItem.onCloseClickPromise = cb; 
+          return newPopupItem.onCloseClickPromise;
+        }
       };
     };
   
-    public close(popupGuid: string): void {
+    public close(popupGuid: string, ...params: any[]): void {
       const currentPopupIndex = this.openPopups.findIndex(
         ({ guid }) => guid === popupGuid,
       );
@@ -68,7 +72,7 @@ export class PopupManager {
   
       const currentPopup = this.openPopups[currentPopupIndex];
   
-      currentPopup.close();
+      currentPopup.close(...params);
   
       const closedPopup = this.openPopups.splice(currentPopupIndex, 1)[0];
       this.closedPopups.unshift(closedPopup);

--- a/src/PopupManager/index.ts
+++ b/src/PopupManager/index.ts
@@ -1,25 +1,15 @@
 import { PopupItem } from "../PopupItem";
 import {uniqueId} from 'lodash';
 import { PopupInstance, PopupProps } from "../models";
-const CLOSED_POPUPS_THRESHOLD = 10;
 
 export type OpenPopupOptions<T> = Omit<T & PopupProps, 'show'>;
 
 export class PopupManager {
     private openPopups: PopupItem[] = [];
-    private readonly _closedPopups: PopupItem[] = [];
     public onPopupsChangeEvents: Function[] = [];
   
     private callPopupsChangeEvents() {
       this.onPopupsChangeEvents.forEach(cb => cb());
-    }
-  
-    private get closedPopups() {
-      this._closedPopups.length = Math.min(
-        this._closedPopups.length,
-        CLOSED_POPUPS_THRESHOLD,
-      );
-      return this._closedPopups;
     }
   
     public subscribeOnPopupsChange(callback: Function): void {
@@ -34,7 +24,7 @@ export class PopupManager {
     }
   
     public get popups() {
-      return [...this.openPopups, ...this.closedPopups];
+      return this.openPopups;
     }
   
     public open = <T>(
@@ -74,15 +64,12 @@ export class PopupManager {
   
       currentPopup.close(...params);
   
-      const closedPopup = this.openPopups.splice(currentPopupIndex, 1)[0];
-      this.closedPopups.unshift(closedPopup);
       this.callPopupsChangeEvents();
     }
   
     public closeAll = (): void => {
       this.openPopups.forEach(popup => {
         popup.close();
-        this.closedPopups.unshift(popup);
       });
       this.openPopups = [];
       this.callPopupsChangeEvents();

--- a/src/PopupManager/index.ts
+++ b/src/PopupManager/index.ts
@@ -7,6 +7,7 @@ export type OpenPopupOptions<T> = Omit<T & PopupProps, 'show'>;
 export class PopupManager {
     private openPopups: PopupItem[] = [];
     public onPopupsChangeEvents: Function[] = [];
+    public deletionTimeout = 500;
   
     private callPopupsChangeEvents() {
       this.onPopupsChangeEvents.forEach(cb => cb());
@@ -63,6 +64,14 @@ export class PopupManager {
       const currentPopup = this.openPopups[currentPopupIndex];
   
       currentPopup.close(...params);
+
+      setTimeout(() => {
+        const currentPopupIndex = this.openPopups.findIndex(
+          ({ guid }) => guid === popupGuid,
+        );
+        this.openPopups.splice(currentPopupIndex, 1);
+      }, this.deletionTimeout)
+      
   
       this.callPopupsChangeEvents();
     }

--- a/src/PopupWrapper/index.tsx
+++ b/src/PopupWrapper/index.tsx
@@ -21,11 +21,11 @@ export function PopupsWrapper({popupManager}: PopupsWrapperProps){
     }, [popupManager, rerender])
 
     const onClose = React.useCallback(function (currentPopup: PopupItem, params: any) {
-        popupManager.close(currentPopup.guid);
+        popupManager.close(currentPopup.guid, params);
         const currentPopupProps: PopupProps = currentPopup.props;
         currentPopupProps &&
         currentPopupProps.onCloseClick &&
-        currentPopupProps.onCloseClick(...params);
+        currentPopupProps.onCloseClick(params);
       }, [popupManager]);
 
     return <> 

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,8 +1,9 @@
 export interface PopupInstance {
     close: Function;
+    onCloseClick: Function;
 }
 
 export interface PopupProps {
-    onCloseClick?: (...args: any[]) => any;
-    show?: boolean;
+    onCloseClick: (...args: any[]) => any;
+    show: boolean;
 }


### PR DESCRIPTION
Added the possibility to write:
```
       let result = await (popupManager?.open<PopupComponentProps>(PopupComponent, {
          customProps: 'Montacchiello',
          onCloseClick: onCloseSpy,
      })
      .onCloseClick(onClosePromiseLikeSpy));

      
      popupManager?.open<PopupComponentProps>(AnotherPopup, {
          anotherCustomProps: result,
          onCloseClick: onCloseSpy,
      });
 ```